### PR TITLE
Text channel selection

### DIFF
--- a/tr-tr-trevor/Cargo.toml
+++ b/tr-tr-trevor/Cargo.toml
@@ -10,3 +10,5 @@ serenity = { version="0.11", default-features = false, features = ["client", "ga
 songbird = "0.3.0"
 audiopus = "0.2"
 tokio = {version="1.21.2", features=["rt-multi-thread", "macros"]}
+futures = "0.3"
+async-std = "1.12.0"

--- a/tr-tr-trevor/Cargo.toml
+++ b/tr-tr-trevor/Cargo.toml
@@ -12,3 +12,5 @@ audiopus = "0.2"
 tokio = {version="1.21.2", features=["rt-multi-thread", "macros"]}
 futures = "0.3"
 async-std = "1.12.0"
+lazy_static = "1.4.0"
+

--- a/tr-tr-trevor/src/commands/transcribe.rs
+++ b/tr-tr-trevor/src/commands/transcribe.rs
@@ -1,16 +1,21 @@
-use crate::{Receiver, EventHandler};
-use songbird::{CoreEvent};
-use serenity::async_trait;
+use crate::Receiver;
+use songbird::CoreEvent;
 
-use serenity::client::Context;
-use serenity::model::id::GuildId;
-use serenity::builder::CreateApplicationCommand;
-use serenity::model::prelude::interaction::application_command::{
-    CommandDataOption,
-    CommandDataOptionValue,
+use serenity::{
+    client::Context,
+    builder::CreateApplicationCommand,
+    model::{
+        id::GuildId,
+        channel::ChannelType,
+        prelude::{
+            command::CommandOptionType,
+            interaction::application_command::{
+                CommandDataOption,
+                CommandDataOptionValue,
+            },
+        }
+    },
 };
-use serenity::model::prelude::command::CommandOptionType;
-use serenity::model::channel::ChannelType;
 
 use std::process::Command;
 

--- a/tr-tr-trevor/src/commands/transcribe.rs
+++ b/tr-tr-trevor/src/commands/transcribe.rs
@@ -1,4 +1,4 @@
-use crate::Receiver;
+use crate::{Receiver, CHANNEL_ID_ARC};
 use songbird::CoreEvent;
 
 use serenity::{
@@ -20,16 +20,16 @@ use serenity::{
 use std::process::Command;
 
 // maybe make channel autoselection? aka. join the sending user's voice channel when unspecified
-pub async fn run(ctx: &Context, guild_id: GuildId, options: &[CommandDataOption]) -> String {
-    let option = options
-    .get(0)
-    .expect("Expected channel option")
-    .resolved
-    .as_ref()
-    .expect("Expected channel object");
+pub async fn run(ctx: &Context, guild_id: GuildId, options: &[CommandDataOption]) -> String {  
+    let option1 = options
+        .get(0)
+        .expect("Expected channel option")
+        .resolved
+        .as_ref()
+        .expect("Expected channel object");
 
     let channel_id = 
-        if let CommandDataOptionValue::Channel(channel) = option {
+        if let CommandDataOptionValue::Channel(channel) = option1 {
             match channel.kind {
                 ChannelType::Voice | 
                 ChannelType::Stage  => channel.id,//format!("{}'s id is {}", channel.name.as_ref().expect("expected channel to have a name."), channel.id),
@@ -38,10 +38,27 @@ pub async fn run(ctx: &Context, guild_id: GuildId, options: &[CommandDataOption]
         } else {
             return "Please provide a valid channel".to_string()
         };
+
+    let option2 = options
+        .get(1)
+        .expect("Expected channel option")
+        .resolved
+        .as_ref()
+        .expect("Expected channel object");
+
+    let text_channel_id = 
+        if let CommandDataOptionValue::Channel(channel) = option2 {
+            match channel.kind {
+                ChannelType::Text | ChannelType::Private | ChannelType::PrivateThread |
+                ChannelType::PublicThread  => channel.id,
+                _                   => return "Select a text channel".to_string(),
+            }
+        } else {
+            return "Please provide a valid channel".to_string()
+        };
     let manager = songbird::get(ctx).await
         .expect("Songbird Voice client placed in at initialisation.").clone();
     let (handler_lock, conn_result) = manager.join(guild_id, channel_id).await;
-
     if let Ok(_) = conn_result {
         
         let mut handler = handler_lock.lock().await;
@@ -73,9 +90,13 @@ pub async fn run(ctx: &Context, guild_id: GuildId, options: &[CommandDataOption]
             Receiver::new(),
         );
     }
+    
+    if let Ok(mut locked_channel_id_ref) = CHANNEL_ID_ARC.lock() {
+        *locked_channel_id_ref = text_channel_id;
+        println!("now outputting text to channel {}", text_channel_id.as_u64());
+    }
 
-
-    format!("Transcription of channel <#{}> begun.", channel_id)
+    format!("Transcription of channel <#{}> to <#{}> begun.", channel_id, text_channel_id)
 }
 
 pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicationCommand {
@@ -86,6 +107,13 @@ pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicatio
             option
                 .name("voice_channel")
                 .description("Voice Channel to connect to")
+                .kind(CommandOptionType::Channel)
+                .required(true)
+        })
+        .create_option( |option| {
+            option
+                .name("text_channel")
+                .description("Text Channel to transcribe to")
                 .kind(CommandOptionType::Channel)
                 .required(true)
         })

--- a/tr-tr-trevor/src/main.rs
+++ b/tr-tr-trevor/src/main.rs
@@ -1,51 +1,76 @@
 mod commands;
-// use crate::commands::*;
 
-use std::env;
+use async_std::task;
+use futures::join;
+
+use std::{
+    fs,
+    fs::File,
+    env,
+    path::Path,
+    io::prelude::*,
+    time::*,
+};
+
+use serenity::{
+    async_trait,
+    prelude::*,
+    http::client::Http,
+    client::{
+        Client, 
+        EventHandler, 
+        Context
+    },
+    model::{
+        gateway::Ready,
+        id::{
+            GuildId, 
+            ChannelId
+        },
+        application::interaction::{
+            Interaction, InteractionResponseType
+        },
+    },
+};
 
 use songbird::{
-    driver::DecodeMode,
-    model::payload::{ClientDisconnect, Speaking},
     Config,
     Event,
     EventContext,
     EventHandler as VoiceEventHandler,
     SerenityInit,
+    driver::DecodeMode,
+    model::payload::{
+        ClientDisconnect, 
+        Speaking
+    },
 };
 
-use serenity::{
-    client::{Client, EventHandler, Context},
-};
 
-use serenity::async_trait;
-use serenity::model::application::interaction::{Interaction, InteractionResponseType};
-use serenity::model::gateway::Ready;
-use serenity::model::id::{GuildId, ChannelId};
-use serenity::prelude::*;
-use serenity::http::client::Http;
-
-use std::fs;
-use std::fs::File;
-use std::path::Path;
-use std::io::prelude::*;
-use std::time::*;
-
-pub fn getTranscribedText() -> String {
-
-    let mut rv: String = String::new();
+/*
+*   get_transcribed_text: gets text that has been transcribed since the last time it was run
+*   specifically, renames message.txt (the output of whisper) to messaged.txt, then reads in
+*   the text from messaged.txt and returns it as a string.
+*   if message.txt does not exist, nothing is done and a new empty string is returned.
+*/
+pub fn get_transcribed_text() -> Option<String> {
     if Path::new("message.txt").exists() {
-        fs::copy("message.txt", "messaged.txt");
-        {
+        if !fs::copy("message.txt", "messaged.txt").is_ok() {
+            return None;
+        }
+        let mut rv: String = String::new();
+        { // restrict file descriptor to close it as early as possible. 
             let mut fd = File::open("messaged.txt").expect("couldnt open file we know exists...");
             let _ = fd.read_to_string(&mut rv);
         }
-        fs::remove_file("message.txt");
-
+        // if the file cant be removed, we really dont care, it'll be overwritten next time we 
+        // transcribe soemthing.
+        let _ = fs::remove_file("message.txt");
+        return Some(rv);
     } else {
-        return String::new();
+        return None;
     }
 
-    return rv;
 }
 
 struct Receiver;
@@ -54,7 +79,7 @@ impl Receiver {
     pub fn new() -> Self {
         // You can manage state here, such as a buffer of audio packet bytes so
         // you can later store them in intervals.
-        Self { }
+        Self {}
     }
 }
 
@@ -125,22 +150,22 @@ impl VoiceEventHandler for Receiver {
                 // An event which fires for every received rtcp packet,
                 // containing the call statistics and reporting information.
                 // println!("RTCP packet received: {:?}", data.packet);
-                let channel_id = ChannelId(1028322765599682592);
+                // let channel_id = ChannelId(1028322765599682592);
 
-                let http = Http::new_with_application_id(
-                    &env::var("DISCORD_TOKEN").expect("Expected Discord token"),
-                    env::var("APP_ID").expect("Expected Application ID").parse::<u64>().unwrap(),
-                );
+                // let http = Http::new_with_application_id(
+                //     &env::var("DISCORD_TOKEN").expect("Expected Discord token"),
+                //     env::var("APP_ID").expect("Expected Application ID").parse::<u64>().unwrap(),
+                // );
 
-                let tmp = getTranscribedText();
+                // let tmp = get_transcribed_text();
 
-                let msg = channel_id.send_message(&http, |m| {
-                    m.content(tmp.clone())
-                }).await;
+                // let msg = channel_id.send_message(&http, |m| {
+                //     m.content(tmp.clone())
+                // }).await;
 
                 // println!("WHY ARENT YOU PRINTING {} TO {:?}", tmp, channel_id);
 
-                fs::remove_file("message.txt");
+                // fs::remove_file("message.txt");
             },
             Ctx::ClientDisconnect(
                 ClientDisconnect {user_id, ..}
@@ -151,7 +176,6 @@ impl VoiceEventHandler for Receiver {
                 // first speaking.
 
                 // println!("Client disconnected: user {:?}", user_id);
-                
             },
             _ => {
                 // We won't be registering this struct for any more event classes.
@@ -234,6 +258,7 @@ impl EventHandler for Handler {
 async fn main() {
     // Configure the client with your Discord bot token in the environment.
     let token = env::var("DISCORD_TOKEN").expect("Expected a token in the environment");
+    let app_id = env::var("APP_ID").expect("Expected Application ID").parse::<u64>().unwrap();
 
     let intents = GatewayIntents::non_privileged()
         | GatewayIntents::MESSAGE_CONTENT;
@@ -243,22 +268,40 @@ async fn main() {
         .decode_mode(DecodeMode::Decode);
 
     // Build our client.
-    let mut client = Client::builder(token, intents)
+    let mut client = Client::builder(token.clone(), intents)
         .event_handler(Handler)
         .register_songbird_from_config(songbird_config)
         .await
         .expect("Error creating client");
 
+    let channel_id = ChannelId(1028322765599682592);
+
+
+    let clientresult = client.start();
+    let tr_loop = print_transcript(channel_id, token, app_id);
+
+    join!(clientresult, tr_loop);
     // Finally, start a single shard, and start listening to events.
     //
     // Shards will automatically attempt to reconnect, and will perform
     // exponential backoff until it reconnects.
-    if let Err(why) = client.start().await {
-        println!("Client error: {:?}", why);
-    }
+    // if let Err(why) = client.start().await {
+    //     println!("Client error: {:?}", why);
+    // }
 }
 
 
-async fn print_transcript(message: String) {
-
+async fn print_transcript(channel_id: ChannelId, token: String, app_id: u64) {
+    let http = Http::new_with_application_id(&token, app_id);
+    loop {
+        // let tmp = get_transcribed_text();
+        match get_transcribed_text() {
+            Some(msg) => {
+                println!("sending {}", msg);
+                let _ = channel_id.send_message(&http, |m| {m.content(msg)}).await;
+            },
+            None => (),//println!("no new content"),
+        }
+        task::sleep(Duration::from_secs(1)).await;
+    }
 }

--- a/tr-tr-trevor/whisper_tr_tr.sh
+++ b/tr-tr-trevor/whisper_tr_tr.sh
@@ -1,6 +1,6 @@
 #!/bin/env sh
 
-model="small"
+model="tiny"
 language="English"
 
 while true; do 

--- a/tr-tr-trevor/whisper_tr_tr.sh
+++ b/tr-tr-trevor/whisper_tr_tr.sh
@@ -5,11 +5,10 @@ language="English"
 
 while true; do 
 	files="$( /bin/ls | tr ' ' '\n' | grep "_processing_" | sort | uniq | head -1)"
-	if [[ $files ]]; then
-		echo "There are files to encode."
+	if [ $files ]; then
+		echo "There are files to encode. the first is $files"
 
 		oldestfile="$files"
-		#"$( echo ${files} | head -1 )"
 		outfilename="$( echo ${oldestfile} | sed -E 's/[0-9]*_processing_([0-9]*)\.pcm/transcribed_\1/g' )"
 		outfileprevious="${outfilename}.msg"
 		messagefile="message.txt"
@@ -27,7 +26,7 @@ while true; do
 
 		echo "Done with ${oldestfile}"
 	else
-		echo "Waiting for something to do"
+		# echo "Waiting for something to do"
 		sleep 5
 	fi
 done


### PR DESCRIPTION
Currently is as functional as the main branch, with the added benefit of continuing to process audio even after being disconnected from all voice calls. also has functionality requiring the user to specify the destination text channel, though this is still such that it is only compatible with public channels.

also merges 'async_print_transcript' branch
